### PR TITLE
Config: Remove inline comments from env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
 # PINATA variables
-NEXT_PUBLIC_PINATA_GATEWAY_URL=UNKNOWN     # Go to: https://app.pinata.cloud/gateway
-PINATA_SUBMARINE_KEY=UNKNOWN               # Go to: https://app.pinata.cloud/developers/v2-api-keys
+# NEXT_PUBLIC_PINATA_GATEWAY_URL —> Go to: https://app.pinata.cloud/gateway
+NEXT_PUBLIC_PINATA_GATEWAY_URL=UNKNOWN
+# PINATA_SUBMARINE_KEY -> Go to: https://app.pinata.cloud/developers/v2-api-keys
+PINATA_SUBMARINE_KEY=UNKNOWN
 
 # LOOPRING variables
-LOOPRING_API_KEY=UNKNOWN                   # Go to: https://loopring.io/#/layer2/security
+# LOOPRING_API_KEY -> Go to: https://loopring.io/#/layer2/security
+LOOPRING_API_KEY=UNKNOWN
 
 # Other environment variables
 SESSION_SECRET=complex_password_at_least_32_characters_long


### PR DESCRIPTION
**Why?**
- The previous `.env.example` file had inline comments, which, unbeknownst to me, were concatenated with the secrets. This led to users experiencing (API) errors since their API secrets were incorrect.

**What?**
- This PR moves the comments one line above, preventing this error from occurring.