### PR TITLE
🐛 Bugfix: Destroy persisted SIWE Session on manual disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopgate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Easily Token-Gate Content using Loopring Layer-2 NFTs and Pinata",
   "author": "Geel <@0xGeel>",
   "license": "BSD-2-Clause",

--- a/src/components/ConnectedPage/EmptyState.tsx
+++ b/src/components/ConnectedPage/EmptyState.tsx
@@ -1,9 +1,16 @@
 import { useDisconnect } from "wagmi";
 import Button from "../Button";
 import { EyeSlashIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useSIWE } from "connectkit";
 
 const EmptyState = () => {
   const { disconnect } = useDisconnect();
+  const { signOut } = useSIWE();
+
+  const onDisconnect = () => {
+    disconnect(); // Disconnect from the connector
+    signOut(); // Destroy any SIWE sessions
+  };
 
   return (
     <div className="px-6 py-8 border-2 border-dashed border-white/20 rounded-md flex flex-col items-center justify-center space-y-8 backdrop-blur-xl bg-slate-900/10 shadow-xl shadow-slate-900/50">
@@ -17,7 +24,7 @@ const EmptyState = () => {
           token-gated content.
         </p>
       </div>
-      <Button onClick={disconnect}>
+      <Button onClick={onDisconnect}>
         <p>Disconnect Wallet</p>
         <XMarkIcon className="w-4 h-4" />
       </Button>


### PR DESCRIPTION
- This caused a UI bug where the user still had a verified SIWE session, but no actively connected account.

(Rare error, but could be triggered in Dev environments when updating the app state / forcing hot reloads).